### PR TITLE
Linux build fixes to allow MTuner to build

### DIFF
--- a/project_qt.lua
+++ b/project_qt.lua
@@ -63,6 +63,9 @@ function addProject_qt(_name, _libProjNotExe, _includes, _prebuildcmds, _extraCo
 		}
 
 		flags { Flags_QtTool }
+		if _libProjNotExe then
+			buildoptions { "-fPIC" }
+		end
 
 		local outputDir = RTM_OUT_DIR
 		if _libProjNotExe == true then

--- a/project_qt.lua
+++ b/project_qt.lua
@@ -65,7 +65,7 @@ function addProject_qt(_name, _libProjNotExe, _includes, _prebuildcmds, _extraCo
 		flags { Flags_QtTool }
 		if os.is("linux") then
 			buildoptions { "-fPIC" }
-		endif
+		end
 
 		local outputDir = RTM_OUT_DIR
 		if _libProjNotExe == true then

--- a/project_qt.lua
+++ b/project_qt.lua
@@ -63,7 +63,9 @@ function addProject_qt(_name, _libProjNotExe, _includes, _prebuildcmds, _extraCo
 		}
 
 		flags { Flags_QtTool }
-		buildoptions { "-fPIC" }
+		if os.is("linux") then
+			buildoptions { "-fPIC" }
+		endif
 
 		local outputDir = RTM_OUT_DIR
 		if _libProjNotExe == true then

--- a/project_qt.lua
+++ b/project_qt.lua
@@ -40,7 +40,16 @@ function addProject_qt(_name, _libProjNotExe, _includes, _prebuildcmds, _extraCo
 		uiFiles		=	{ os.matchfiles( project().path .. "src/**.ui") }
 		qrcFiles	= 	{ os.matchfiles( project().path .. "src/**.qrc") }
 		tsFiles		= 	{ os.matchfiles( project().path .. "src/**.ts") }
-		libsToLink	=	{ "Core", "Gui", "Widgets", "Network", "WinExtras" }
+
+		if os.is("windows") then
+			extras = "WinExtras"
+		elseif os.is("linux") then
+			extras = "X11Extras"
+		else
+			extras = nil
+		end
+
+		libsToLink	=	{ "Core", "Gui", "Widgets", "Network", extras }
 
 		addPCH( project().path .. "src/", project().name )
 

--- a/project_qt.lua
+++ b/project_qt.lua
@@ -63,9 +63,7 @@ function addProject_qt(_name, _libProjNotExe, _includes, _prebuildcmds, _extraCo
 		}
 
 		flags { Flags_QtTool }
-		if _libProjNotExe then
-			buildoptions { "-fPIC" }
-		end
+		buildoptions { "-fPIC" }
 
 		local outputDir = RTM_OUT_DIR
 		if _libProjNotExe == true then

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -21,10 +21,28 @@ qtDirectory = arg[3] or qtDirectory
 
 lua_version = _VERSION:match(" (5%.[123])$") or "5.1"
 
+findLast = function(string, what, plain)
+	plain = plain or true
+	local lastMatch = 1
+	local result = -1
+	local thisMatch
+
+	while lastMatch ~= -1 do
+		thisMatch = string:find(what, lastMatch, plain)
+		if thisMatch == nil then
+			lastMatch = -1
+		else
+			result = thisMatch
+			lastMatch = result + 1
+		end
+	end
+	return result
+end
+
 local sourceDir = ""
 if arg[2] ~= nil then
 	local projName = arg[4]
-	sourceDir = arg[2]:sub(1, arg[2]:find(projName) + string.len(projName))
+	sourceDir = arg[2]:sub(1, findLast(arg[2], projName) + string.len(projName))
 	sourceDir = sourceDir .. "src/"
 end
 

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -50,7 +50,7 @@ end
 local sourceDir = ""
 if arg[2] ~= nil then
 	local projName = arg[4]
-	sourceDir = arg[2]:sub(1, findLast(arg[2], projName .. "/") + string.len(projName))
+	sourceDir = arg[2]:sub(1, findLast(arg[2], projName .. del) + string.len(projName))
 	sourceDir = sourceDir .. "src/"
 end
 

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -179,7 +179,7 @@ elseif arg[1] == "-rcc" then
 		fullRCCPath = '""'..qtQRCExe..'" -name "'..getFileNameNoExtFromPath( arg[2] )..'" "'..arg[2]..'" -o "'..outputFileName..'""'
 	end
 
-	if( 0 ~= os.execute( fullRCCPath ) ) then
+	if 0 ~= runProgram(fullRCCPath) then
 		print( BuildErrorWarningString( debug.getinfo(1).currentline, true, [[RCC Failed to generate ]]..outputFileName, 6 ) ); io.stdout:flush()
 	else
 		--print( "RCC Created "..outputFileName )
@@ -196,7 +196,7 @@ elseif arg[1] == "-uic" then
 			fullUICPath = '""'..qtUICExe..'" "'..arg[2]..'" -o "'..outputFileName..'""'
 		end
 
-		if( 0 ~= os.execute( fullUICPath ) ) then
+		if 0 ~= runProgram(fullUICPath) then
 			print( BuildErrorWarningString( debug.getinfo(1).currentline, true, [[UIC Failed to generate ]]..outputFileName, 7 ) ); io.stdout:flush()
 		else
 			--print( "UIC Created "..outputFileName )
@@ -213,7 +213,7 @@ elseif arg[1] == "-ts" then
 			fullTSPath = '""'..qtTSExe..'" "'..arg[2]
 		end
 
-		if( 0 ~= os.execute( fullTSPath ) ) then
+		if 0 ~= runProgram( fullTSPath) then
 			print( BuildErrorWarningString( debug.getinfo(1).currentline, true, [[UIC Failed to generate ]]..outputFileName, 7 ) ); io.stdout:flush()
 		else
 			--print( "UIC Created "..outputFileName )

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -42,7 +42,7 @@ end
 local sourceDir = ""
 if arg[2] ~= nil then
 	local projName = arg[4]
-	sourceDir = arg[2]:sub(1, findLast(arg[2], projName) + string.len(projName))
+	sourceDir = arg[2]:sub(1, findLast(arg[2], projName .. "/") + string.len(projName))
 	sourceDir = sourceDir .. "src/"
 end
 

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -21,6 +21,14 @@ qtDirectory = arg[3] or qtDirectory
 
 lua_version = _VERSION:match(" (5%.[123])$") or "5.1"
 
+windows = package.config:sub( 1, 1 ) == "\\"
+windowsExe = ".exe"
+del = "\\"
+if not windows then
+	del = "/"
+	windowsExe = ""
+end
+
 findLast = function(string, what, plain)
 	plain = plain or true
 	local lastMatch = 1
@@ -83,14 +91,6 @@ qtMocPostfix	= "_moc"
 qtQRCPostfix	= "_qrc"
 qtUIPostfix		= "_ui"
 qtTSPostfix		= "_ts"
-
-windows = package.config:sub( 1, 1 ) == "\\"
-windowsExe = ".exe"
-del = "\\"
-if not windows then
-	del = "/"
-	windowsExe = ""
-end
 
 function file_exists(name)
    local f=io.open(name,"r")

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -19,6 +19,8 @@ RTM_QT_FILES_PATH_TS	= "../.qt/qt_qm"
 local qtDirectory = ""
 qtDirectory = arg[3] or qtDirectory
 
+lua_version = _VERSION:match(" (5%.[123])$") or "5.1"
+
 local sourceDir = ""
 if arg[2] ~= nil then
 	local projName = arg[4]
@@ -144,12 +146,20 @@ if arg[1] == "-moc" then
 
 	if checkUpToDate(outputFileName) == true then return end
 	
-	local fullMOCPath = qtMocExe.." \""..arg[2].. "\" -I \"" .. getPath(arg[2]) .. "\" -o \"" .. outputFileName .."\" -f".. arg[4] .. "_pch.h -f" .. arg[5] .. "\""
+	local fullMOCPath = qtMocExe.." \""..arg[2].. "\" -I \"" .. getPath(arg[2]) .. "\" -o \"" .. outputFileName .."\" -f\"".. arg[4] .. "_pch.h\" -f\"" .. arg[5] .. "\""
 	if windows then
 		fullMOCPath = '""'..qtMocExe..'" "'..arg[2].. '" -I "' .. getPath(arg[2]) .. '" -o "' .. outputFileName ..'"' .. " -f".. arg[4] .. "_pch.h -f" .. arg[5] .. '"'
 	end
 
-	if( 0 ~= os.execute( fullMOCPath ) ) then
+	local result = 1
+	if lua_version == "5.3" then
+		local value, type
+		value, type, result = os.execute(fullMOCPath)
+	else
+		result = os.execute(fullMOCPath)
+	end
+
+	if 0 ~= result then
 		print( BuildErrorWarningString( debug.getinfo(1).currentline, true, [[MOC Failed to generate ]]..outputFileName, 5 ) ); io.stdout:flush()
 	else
 		--print( "MOC Created "..outputFileName )

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -139,6 +139,17 @@ getPath=function(str,sep)
     return str:match("(.*"..sep..")")
 end
 
+runProgram = function(command)
+	local result = 1
+	if lua_version == "5.3" then
+		local value, type
+		value, type, result = os.execute(command)
+	else
+		result = os.execute(command)
+	end
+	return result
+end
+
 if arg[1] == "-moc" then
 
 	lfs.mkdir( qtMocOutputDirectory )
@@ -151,15 +162,7 @@ if arg[1] == "-moc" then
 		fullMOCPath = '""'..qtMocExe..'" "'..arg[2].. '" -I "' .. getPath(arg[2]) .. '" -o "' .. outputFileName ..'"' .. " -f".. arg[4] .. "_pch.h -f" .. arg[5] .. '"'
 	end
 
-	local result = 1
-	if lua_version == "5.3" then
-		local value, type
-		value, type, result = os.execute(fullMOCPath)
-	else
-		result = os.execute(fullMOCPath)
-	end
-
-	if 0 ~= result then
+	if 0 ~= runProgram(fullMOCPath) then
 		print( BuildErrorWarningString( debug.getinfo(1).currentline, true, [[MOC Failed to generate ]]..outputFileName, 5 ) ); io.stdout:flush()
 	else
 		--print( "MOC Created "..outputFileName )

--- a/toolchain.lua
+++ b/toolchain.lua
@@ -735,9 +735,9 @@ function commonConfig(_filter, _isLib, _isSharedLib, _rappUsed)
 			"-Wunused-value",
 			"-Wundef",
 		}
---		buildoptions_cpp {
---			"-std=c++11",
---		}
+		buildoptions_cpp {
+			"-std=c++11",
+		}
 		links {
 			"rt",
 			"dl",

--- a/toolchain.lua
+++ b/toolchain.lua
@@ -305,9 +305,11 @@ function rmdir(_dirname)
 
 	if os.isdir(dir) then
 		if os.is("windows") then
-			dir = dir .. " /s /q"
+			dir = "rmdir /s /q " .. dir
+		else
+			dir = "rm -rf " .. dir
 		end
-		os.execute("rmdir " .. dir)
+		os.execute(dir)
 	end
 end
 

--- a/toolchain.lua
+++ b/toolchain.lua
@@ -304,7 +304,9 @@ function rmdir(_dirname)
 	end
 
 	if os.isdir(dir) then
-		dir = dir .. " /s /q"
+		if os.is("windows") then
+			dir = dir .. " /s /q"
+		end
 		os.execute("rmdir " .. dir)
 	end
 end


### PR DESCRIPTION
There are a couple of flaws that prevent any possible Linux based built on either a GCC that assumes C++98 by default, or due to bad options being passed to rmdir that make it fail out during the Qt part of the build.

These changes fix this.