### PR TITLE
A more well tested patch on the path calc in qtprebuild

### DIFF
--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -51,7 +51,6 @@ local sourceDir = ""
 if arg[2] ~= nil then
 	local projName = arg[4]
 	sourceDir = arg[2]:sub(1, findLast(arg[2], projName .. "/") + string.len(projName))
-	print(arg[2], sourceDir)
 	sourceDir = sourceDir .. "src/"
 end
 

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -50,7 +50,7 @@ end
 local sourceDir = ""
 if arg[2] ~= nil then
 	local projName = arg[4]
-	sourceDir = arg[2]:sub(1, arg[2]:find(projName) + string.len(projName))
+	sourceDir = arg[2]:sub(1, findLast(arg[2], projName .. del) + string.len(projName))
 	sourceDir = sourceDir .. "src/"
 end
 

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -29,14 +29,14 @@ if not windows then
 	windowsExe = ""
 end
 
-findLast = function(string, what, plain)
+findLast = function(str, what, plain)
 	plain = plain or true
 	local lastMatch = 1
 	local result = -1
 	local thisMatch
 
 	while lastMatch ~= -1 do
-		thisMatch = string:find(what, lastMatch, plain)
+		thisMatch = str:find(what, lastMatch, plain)
 		if thisMatch == nil then
 			lastMatch = -1
 		else
@@ -180,7 +180,6 @@ if arg[1] == "-moc" then
 	if windows then
 		fullMOCPath = '""'..qtMocExe..'" "'..arg[2].. '" -I "' .. getPath(arg[2]) .. '" -o "' .. outputFileName ..'"' .. " -f".. arg[4] .. "_pch.h -f" .. arg[5] .. '"'
 	end
-	print(getPath(arg[2]))
 	print(outputFileName)
 
 	if 0 ~= runProgram(fullMOCPath) then

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -50,9 +50,9 @@ end
 local sourceDir = ""
 if arg[2] ~= nil then
 	local projName = arg[4]
-	sourceDir = arg[2]:sub(1, findLast(arg[2], projName .. del) + string.len(projName))
-	print(sourceDir)
-	sourceDir = sourceDir .. "src" .. del
+	sourceDir = arg[2]:sub(1, findLast(arg[2], projName .. "/") + string.len(projName))
+	print(arg[2], sourceDir)
+	sourceDir = sourceDir .. "src/"
 end
 
 function BuildErrorWarningString( line, isError, message, code )
@@ -180,7 +180,6 @@ if arg[1] == "-moc" then
 	if windows then
 		fullMOCPath = '""'..qtMocExe..'" "'..arg[2].. '" -I "' .. getPath(arg[2]) .. '" -o "' .. outputFileName ..'"' .. " -f".. arg[4] .. "_pch.h -f" .. arg[5] .. '"'
 	end
-	print(outputFileName)
 
 	if 0 ~= runProgram(fullMOCPath) then
 		print( BuildErrorWarningString( debug.getinfo(1).currentline, true, [[MOC Failed to generate ]]..outputFileName, 5 ) ); io.stdout:flush()

--- a/qtprebuild.lua
+++ b/qtprebuild.lua
@@ -51,7 +51,8 @@ local sourceDir = ""
 if arg[2] ~= nil then
 	local projName = arg[4]
 	sourceDir = arg[2]:sub(1, findLast(arg[2], projName .. del) + string.len(projName))
-	sourceDir = sourceDir .. "src/"
+	print(sourceDir)
+	sourceDir = sourceDir .. "src" .. del
 end
 
 function BuildErrorWarningString( line, isError, message, code )
@@ -179,6 +180,8 @@ if arg[1] == "-moc" then
 	if windows then
 		fullMOCPath = '""'..qtMocExe..'" "'..arg[2].. '" -I "' .. getPath(arg[2]) .. '" -o "' .. outputFileName ..'"' .. " -f".. arg[4] .. "_pch.h -f" .. arg[5] .. '"'
 	end
+	print(getPath(arg[2]))
+	print(outputFileName)
 
 	if 0 ~= runProgram(fullMOCPath) then
 		print( BuildErrorWarningString( debug.getinfo(1).currentline, true, [[MOC Failed to generate ]]..outputFileName, 5 ) ); io.stdout:flush()


### PR DESCRIPTION
Re-introduced the findLast() fix with one important change - the delimiter used in the matching. I was unaware when I first wrote this that you use "/" on windows too for arg[2]. Ergo, the search string was never being found and the function was returning -1, which was promptly getting the project name length added onto it.